### PR TITLE
allow aborting a readable stream using destroy

### DIFF
--- a/lib/readable-search.js
+++ b/lib/readable-search.js
@@ -72,6 +72,16 @@ ReadableHits.prototype._shift = function() {
   this.push(this.parseHit(this._hits[this._current]));
 };
 
+ReadableHits.prototype.destroy = function() {
+  if (this.destroyed) {
+    return;
+  }
+  this.destroyed = true;
+  this._next = false;
+  this.unpipe();
+};
+
+
 function identity(hit) {
   return hit;
 }


### PR DESCRIPTION
If one has a huge query (scan+scroll) that's hooked up to `ReadableSearch`, this introduces `.destroy()` which will abort the query and stop scrolling the server if this is desired.