### PR TITLE
readable-stream 'size' control

### DIFF
--- a/lib/readable-search.js
+++ b/lib/readable-search.js
@@ -53,7 +53,7 @@ ReadableHits.prototype._fetchNextPage = function() {//size) {
       self.emit('error', e);
       return self.push(null);
     }
-    self.total = resp.hits.total;
+    self.total = resp.hits.hits.length;
     self._hits = resp.hits.hits;
     self.from += self._hits.length;
     if (self.from >= self.total) {


### PR DESCRIPTION
Changing the output control based on the query size. Before the whole
index was streamed - with this change - only matched data is being
returned and sent to the stream.