### PR TITLE
Checks if resp exists

### DIFF
--- a/lib/writable-bulk.js
+++ b/lib/writable-bulk.js
@@ -77,7 +77,7 @@ WritableBulk.prototype._flushBulk = function(callback) {
     if (e) {
       self.emit('error', e);
     }
-    if (resp.errors && resp.items) {
+    if (resp && resp.errors && resp.items) {
       for (var i = 0; i < resp.items.length; i++) {
         var bulkItemResp = resp.items[i];
         var key = Object.keys(bulkItemResp)[0];


### PR DESCRIPTION
```
TypeError Cannot read property 'errors' of undefined 
    /app/node_modules/elasticsearch-streams/lib/writable-bulk.js:80:13 none
    /app/node_modules/elasticsearch/src/lib/transport.js:312:9 respond
    /app/node_modules/elasticsearch/src/lib/transport.js:211:7 sendReqWithConnection
    /app/node_modules/elasticsearch/src/lib/connection_pool.js:213:7 next
    node.js:381:11 _tickDomainCallback
```