### PR TITLE
Correctly display bulk error from elastic search

### DIFF
--- a/lib/writable-bulk.js
+++ b/lib/writable-bulk.js
@@ -82,7 +82,10 @@ WritableBulk.prototype._flushBulk = function(callback) {
         var bulkItemResp = resp.items[i];
         var key = Object.keys(bulkItemResp)[0];
         if (bulkItemResp[key].error) {
-          self.emit('error', new Error(bulkItemResp[key].error));
+          var err = new Error(bulkItemResp[key].error.reason || bulkItemResp[key].error);
+          err.reason = bulkItemResp[key].error.reason;
+          err.type = bulkItemResp[key].error.type;
+          self.emit('error', err);
         }
       }
     }


### PR DESCRIPTION
When an error occur message is:
- Error: [object Object]
Now it’s the real message:
- Error: Field [_id] is defined twice in [mytype]
